### PR TITLE
Added an overtime victory condition

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
 	"mapFolder": "risk_europe.w3x",
 	"mapName": "Risk Europe",
-	"mapVersion": "2.05b",
+	"mapVersion": "2.05c",
 	"minifyScript": false,
 	"gameExecutable": "D:\\Warcraft III\\_retail_\\x86_64\\Warcraft III.exe",
 	"outputFolder": "C:\\Users\\Daniel\\Documents\\Warcraft III\\Maps\\Download\\(0) testing",

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
 	"mapFolder": "risk_europe.w3x",
 	"mapName": "Risk Europe",
-	"mapVersion": "2.04c",
+	"mapVersion": "2.05",
 	"minifyScript": false,
 	"gameExecutable": "D:\\Warcraft III\\_retail_\\x86_64\\Warcraft III.exe",
 	"outputFolder": "C:\\Users\\Daniel\\Documents\\Warcraft III\\Maps\\Download\\(0) testing",

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
 	"mapFolder": "risk_europe.w3x",
 	"mapName": "Risk Europe",
-	"mapVersion": "2.05",
+	"mapVersion": "2.05b",
 	"minifyScript": false,
 	"gameExecutable": "D:\\Warcraft III\\_retail_\\x86_64\\Warcraft III.exe",
 	"outputFolder": "C:\\Users\\Daniel\\Documents\\Warcraft III\\Maps\\Download\\(0) testing",

--- a/maps/risk_europe.w3x/war3mapImported/risk.fdf
+++ b/maps/risk_europe.w3x/war3mapImported/risk.fdf
@@ -225,9 +225,9 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
     	PopupMenuFrame "OvertimePopupMenu",
 			Frame "MENU" "OvertimePopupMenu" INHERITS WITHCHILDREN "EscMenuPopupMenuMenuTemplate" {
 				MenuItem "Off",     -2,
-				MenuItem "Turn 30",     -2,
 				MenuItem "Turn 60",     -2,
 				MenuItem "Turn 90",     -2,
+				MenuItem "Turn 120",     -2,
 			}
 		}
 

--- a/maps/risk_europe.w3x/war3mapImported/risk.fdf
+++ b/maps/risk_europe.w3x/war3mapImported/risk.fdf
@@ -224,10 +224,9 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		SetPoint TOP,"PopupMenus",TOP,0.0,-0.12,
     	PopupMenuFrame "OvertimePopupMenu",
 			Frame "MENU" "OvertimePopupMenu" INHERITS WITHCHILDREN "EscMenuPopupMenuMenuTemplate" {
+				MenuItem "Turbo (Turn 30)",     -2,
+				MenuItem "Long (Turn 120)",     -2,
 				MenuItem "Off",     -2,
-				MenuItem "Turn 60",     -2,
-				MenuItem "Turn 90",     -2,
-				MenuItem "Turn 120",     -2,
 			}
 		}
 
@@ -382,7 +381,7 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 			LayerStyle "IGNORETRACKEVENTS", 
 			FontJustificationH JUSTIFYLEFT,
 			FontJustificationV JUSTIFYMIDDLE,
-			Text "Off",
+			Text "Turbo (Turn 30)",
 		}
 
 		Frame "TEXT" "PromodeOption" {

--- a/maps/risk_europe.w3x/war3mapImported/risk.fdf
+++ b/maps/risk_europe.w3x/war3mapImported/risk.fdf
@@ -201,7 +201,7 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		}
 
 		Frame "POPUPMENU" "FogPopup" INHERITS WITHCHILDREN "MyPopupTemplate" {
-		SetPoint TOP,"PopupMenus",TOP,0.0,-0.05,
+		SetPoint TOP,"PopupMenus",TOP,0.0,-0.04,
 		PopupMenuFrame "FogPopupMenu",
 			Frame "MENU" "FogPopupMenu" INHERITS WITHCHILDREN "EscMenuPopupMenuMenuTemplate" {
 				MenuItem "Off",     -2,
@@ -211,7 +211,7 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		}
 
 		Frame "POPUPMENU" "DiplomacyPopup" INHERITS WITHCHILDREN "MyPopupTemplate" {
-		SetPoint TOP,"PopupMenus",TOP,0.0,-0.1,
+		SetPoint TOP,"PopupMenus",TOP,0.0,-0.08,
     	PopupMenuFrame "DiplomacyPopupMenu",
 			Frame "MENU" "DiplomacyPopupMenu" INHERITS WITHCHILDREN "EscMenuPopupMenuMenuTemplate" {
 				MenuItem "FFA",     -2,
@@ -223,7 +223,7 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		Frame "GLUECHECKBOX" "PromodeCheckbox" {
 		Width 0.024,
 		Height 0.024,
-		SetPoint TOP,"PopupMenus",TOP,-0.053,-0.15,
+		SetPoint TOP,"PopupMenus",TOP,-0.053,-0.16,
 
 		ControlBackdrop "EscMenuCheckBoxBackdrop",
 			Frame "BACKDROP" "EscMenuCheckBoxBackdrop" {
@@ -262,6 +262,64 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 				HighlightAlphaMode "BLEND",
 			}
 		}
+
+		Frame "SLIDER" "EscMenuSliderTemplate" {
+			Height 0.012,
+			Width 0.13,
+			SliderLayoutHorizontal,
+			SetPoint TOPLEFT,"PopupMenus",TOPLEFT, 0.005, -0.128,
+			
+			SliderInitialValue 90,
+			SliderMinValue 60,
+			SliderMaxValue 120,
+			SliderStepSize 10,
+
+			ControlBackdrop "EscMenuScrollBarBackdropTemplate",
+			Frame "BACKDROP" "EscMenuScrollBarBackdropTemplate" {
+				DecorateFileNames,
+				BackdropTileBackground,
+				BackdropBackground  "EscMenuSliderBackground",
+				BackdropCornerFlags "UL|UR|BL|BR|T|L|B|R",
+				BackdropCornerSize  0.006,
+				BackdropBackgroundSize 0.006,
+				BackdropBackgroundInsets 0.0025 0.0025 0.0025 0.0025,
+				BackdropEdgeFile  "EscMenuSliderBorder",
+				BackdropBlendAll,
+			}
+
+			ControlDisabledBackdrop "EscMenuScrollBarDisabledBackdrop",
+			Frame "BACKDROP" "EscMenuScrollBarDisabledBackdrop" {
+				DecorateFileNames,
+				BackdropTileBackground,
+				BackdropBackground  "EscMenuSliderBackground",
+				BackdropCornerFlags "UL|UR|BL|BR|T|L|B|R",
+				BackdropCornerSize  0.006,
+				BackdropBackgroundSize 0.006,
+				BackdropBackgroundInsets 0.0025 0.0025 0.0025 0.0025,
+				BackdropEdgeFile  "EscMenuSliderDisabledBorder",
+				BackdropBlendAll,
+			}
+
+			SliderThumbButtonFrame "EscMenuThumbButtonTemplate",
+			Frame "BUTTON" "EscMenuThumbButtonTemplate" {
+				Width 0.016,
+				Height 0.016,
+
+				ControlBackdrop "EscMenuThumbButtonBackdropTemplate",
+				Frame "BACKDROP" "EscMenuThumbButtonBackdropTemplate" {
+					DecorateFileNames,
+					BackdropBlendAll,
+					BackdropBackground  "EscMenuSliderThumbButton",
+				}
+
+				ControlDisabledBackdrop "EscMenuThumbButtonDisabledBackdrop",
+				Frame "BACKDROP" "EscMenuThumbButtonDisabledBackdrop" {
+					DecorateFileNames,
+					BackdropBlendAll,
+					BackdropBackground  "EscMenuSliderDisabledThumbButton",
+				}
+			}
+		}
 	}
 
 	Frame "FRAME" "PopupLabels" {
@@ -281,7 +339,7 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		}
 
 		Frame "TEXT" "FogLabel" {
-			SetPoint TOPLEFT,"PopupLabels",TOPLEFT, 0, -0.05,
+			SetPoint TOPLEFT,"PopupLabels",TOPLEFT, 0, -0.04,
 			DecorateFileNames,
 			FrameFont "MasterFont", 0.012,"",
 			FontColor 1.0 0.8 0.0 1.0,
@@ -292,7 +350,7 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		}
 
 		Frame "TEXT" "DiplomacyLabel" {
-			SetPoint TOPLEFT,"PopupLabels",TOPLEFT, 0, -0.1,
+			SetPoint TOPLEFT,"PopupLabels",TOPLEFT, 0, -0.08,
 			DecorateFileNames,
 			FrameFont "MasterFont", 0.012,"",
 			FontColor 1.0 0.8 0.0 1.0,
@@ -313,8 +371,19 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		// 	Text "Team Size:",
 		// }
 
+		Frame "TEXT" "OvertimeLabel" {
+			SetPoint TOPLEFT,"PopupLabels",TOPLEFT, 0, -0.12,
+			DecorateFileNames,
+			FrameFont "MasterFont", 0.012,"",
+			FontColor 1.0 0.8 0.0 1.0,
+			LayerStyle "IGNORETRACKEVENTS",
+			FontJustificationH JUSTIFYLEFT,
+			FontJustificationV JUSTIFYMIDDLE,
+			Text "Overtime:",
+		}
+
 		Frame "TEXT" "PromodeLabel" {
-			SetPoint TOPLEFT,"PopupLabels",TOPLEFT, 0, -0.15,
+			SetPoint TOPLEFT,"PopupLabels",TOPLEFT, 0, -0.16,
 			DecorateFileNames,
 			FrameFont "MasterFont", 0.012,"",
 			FontColor 1.0 0.8 0.0 1.0,

--- a/maps/risk_europe.w3x/war3mapImported/risk.fdf
+++ b/maps/risk_europe.w3x/war3mapImported/risk.fdf
@@ -161,7 +161,7 @@ Frame "POPUPMENU" "MyPopupTemplate" {
 
 Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 	Width 0.25f,
-    Height 0.31f,
+    Height 0.33f,
 	SetPoint CENTER, "ConsoleUI", CENTER, 0.0,0.05,
 
 	Frame "TEXT" "SettingsTitle" {
@@ -220,10 +220,21 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 			}
 		}
 
+		Frame "POPUPMENU" "OvertimePopup" INHERITS WITHCHILDREN "MyPopupTemplate" {
+		SetPoint TOP,"PopupMenus",TOP,0.0,-0.12,
+    	PopupMenuFrame "OvertimePopupMenu",
+			Frame "MENU" "OvertimePopupMenu" INHERITS WITHCHILDREN "EscMenuPopupMenuMenuTemplate" {
+				MenuItem "Off",     -2,
+				MenuItem "Turn 30",     -2,
+				MenuItem "Turn 60",     -2,
+				MenuItem "Turn 90",     -2,
+			}
+		}
+
 		Frame "GLUECHECKBOX" "PromodeCheckbox" {
 		Width 0.024,
 		Height 0.024,
-		SetPoint TOP,"PopupMenus",TOP,-0.053,-0.16,
+		SetPoint TOP,"PopupMenus",TOP,-0.053,-0.17,
 
 		ControlBackdrop "EscMenuCheckBoxBackdrop",
 			Frame "BACKDROP" "EscMenuCheckBoxBackdrop" {
@@ -260,64 +271,6 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 				HighlightType "FILETEXTURE",
 				HighlightAlphaFile "EscMenuDisabledCheckHighlight",
 				HighlightAlphaMode "BLEND",
-			}
-		}
-
-		Frame "SLIDER" "EscMenuSliderTemplate" {
-			Height 0.012,
-			Width 0.13,
-			SliderLayoutHorizontal,
-			SetPoint TOPLEFT,"PopupMenus",TOPLEFT, 0.005, -0.128,
-			
-			SliderInitialValue 90,
-			SliderMinValue 60,
-			SliderMaxValue 120,
-			SliderStepSize 10,
-
-			ControlBackdrop "EscMenuScrollBarBackdropTemplate",
-			Frame "BACKDROP" "EscMenuScrollBarBackdropTemplate" {
-				DecorateFileNames,
-				BackdropTileBackground,
-				BackdropBackground  "EscMenuSliderBackground",
-				BackdropCornerFlags "UL|UR|BL|BR|T|L|B|R",
-				BackdropCornerSize  0.006,
-				BackdropBackgroundSize 0.006,
-				BackdropBackgroundInsets 0.0025 0.0025 0.0025 0.0025,
-				BackdropEdgeFile  "EscMenuSliderBorder",
-				BackdropBlendAll,
-			}
-
-			ControlDisabledBackdrop "EscMenuScrollBarDisabledBackdrop",
-			Frame "BACKDROP" "EscMenuScrollBarDisabledBackdrop" {
-				DecorateFileNames,
-				BackdropTileBackground,
-				BackdropBackground  "EscMenuSliderBackground",
-				BackdropCornerFlags "UL|UR|BL|BR|T|L|B|R",
-				BackdropCornerSize  0.006,
-				BackdropBackgroundSize 0.006,
-				BackdropBackgroundInsets 0.0025 0.0025 0.0025 0.0025,
-				BackdropEdgeFile  "EscMenuSliderDisabledBorder",
-				BackdropBlendAll,
-			}
-
-			SliderThumbButtonFrame "EscMenuThumbButtonTemplate",
-			Frame "BUTTON" "EscMenuThumbButtonTemplate" {
-				Width 0.016,
-				Height 0.016,
-
-				ControlBackdrop "EscMenuThumbButtonBackdropTemplate",
-				Frame "BACKDROP" "EscMenuThumbButtonBackdropTemplate" {
-					DecorateFileNames,
-					BackdropBlendAll,
-					BackdropBackground  "EscMenuSliderThumbButton",
-				}
-
-				ControlDisabledBackdrop "EscMenuThumbButtonDisabledBackdrop",
-				Frame "BACKDROP" "EscMenuThumbButtonDisabledBackdrop" {
-					DecorateFileNames,
-					BackdropBlendAll,
-					BackdropBackground  "EscMenuSliderDisabledThumbButton",
-				}
 			}
 		}
 	}
@@ -360,17 +313,6 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 			Text "Diplomacy:",
 		}
 
-		// Frame "TEXT" "DiplomacySliderLabel" {
-		// 	SetPoint TOPLEFT,"PopupLabels",TOPLEFT, 0, -0.15,
-		// 	DecorateFileNames,
-		// 	FrameFont "MasterFont", 0.012,"",
-		// 	FontColor 1.0 0.8 0.0 1.0,
-		// 	LayerStyle "IGNORETRACKEVENTS", 
-		// 	FontJustificationH JUSTIFYLEFT,
-		// 	FontJustificationV JUSTIFYMIDDLE,
-		// 	Text "Team Size:",
-		// }
-
 		Frame "TEXT" "OvertimeLabel" {
 			SetPoint TOPLEFT,"PopupLabels",TOPLEFT, 0, -0.12,
 			DecorateFileNames,
@@ -383,7 +325,7 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		}
 
 		Frame "TEXT" "PromodeLabel" {
-			SetPoint TOPLEFT,"PopupLabels",TOPLEFT, 0, -0.16,
+			SetPoint TOPLEFT,"PopupLabels",TOPLEFT, 0, -0.17,
 			DecorateFileNames,
 			FrameFont "MasterFont", 0.012,"",
 			FontColor 1.0 0.8 0.0 1.0,
@@ -432,16 +374,16 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 			Text "FFA",
 		}
 
-		// Frame "TEXT" "DiplomacySliderOption" {
-		// 	SetPoint TOPLEFT,"PopupMenuOptions",TOPLEFT, 0, -0.15,
-		// 	DecorateFileNames,
-		// 	FrameFont "MasterFont", 0.012,"",
-		// 	FontColor 1.0 0.8 0.0 1.0,
-		// 	LayerStyle "IGNORETRACKEVENTS", 
-		// 	FontJustificationH JUSTIFYLEFT,
-		// 	FontJustificationV JUSTIFYMIDDLE,
-		// 	Text "Team Size:",
-		// }
+		Frame "TEXT" "OvertimeOption" {
+			SetPoint TOPLEFT,"PopupMenuOptions",TOPLEFT, 0, -0.1,
+			DecorateFileNames,
+			FrameFont "MasterFont", 0.012,"",
+			FontColor 1.0 0.8 0.0 1.0,
+			LayerStyle "IGNORETRACKEVENTS", 
+			FontJustificationH JUSTIFYLEFT,
+			FontJustificationV JUSTIFYMIDDLE,
+			Text "Off",
+		}
 
 		Frame "TEXT" "PromodeOption" {
 			SetPoint TOPLEFT,"PopupMenuOptions",TOPLEFT, 0, -0.15,

--- a/maps/risk_europe.w3x/war3mapImported/risk.fdf
+++ b/maps/risk_europe.w3x/war3mapImported/risk.fdf
@@ -352,7 +352,7 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		}
 
 		Frame "TEXT" "FogOption" {
-			SetPoint TOPLEFT,"PopupMenuOptions",TOPLEFT, 0, -0.05,
+			SetPoint TOPLEFT,"PopupMenuOptions",TOPLEFT, 0, -0.04,
 			DecorateFileNames,
 			FrameFont "MasterFont", 0.012,"",
 			FontColor 1.0 0.8 0.0 1.0,
@@ -363,7 +363,7 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		}
 
 		Frame "TEXT" "DiplomacyOption" {
-			SetPoint TOPLEFT,"PopupMenuOptions",TOPLEFT, 0, -0.1,
+			SetPoint TOPLEFT,"PopupMenuOptions",TOPLEFT, 0, -0.08,
 			DecorateFileNames,
 			FrameFont "MasterFont", 0.012,"",
 			FontColor 1.0 0.8 0.0 1.0,
@@ -374,7 +374,7 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		}
 
 		Frame "TEXT" "OvertimeOption" {
-			SetPoint TOPLEFT,"PopupMenuOptions",TOPLEFT, 0, -0.1,
+			SetPoint TOPLEFT,"PopupMenuOptions",TOPLEFT, 0, -0.12,
 			DecorateFileNames,
 			FrameFont "MasterFont", 0.012,"",
 			FontColor 1.0 0.8 0.0 1.0,
@@ -385,7 +385,7 @@ Frame "BACKDROP" "SettingsView" INHERITS "QuestButtonBaseTemplate" {
 		}
 
 		Frame "TEXT" "PromodeOption" {
-			SetPoint TOPLEFT,"PopupMenuOptions",TOPLEFT, 0, -0.15,
+			SetPoint TOPLEFT,"PopupMenuOptions",TOPLEFT, 0, -0.17,
 			DecorateFileNames,
 			FrameFont "MasterFont", 0.012,"",
 			FontColor 1.0 0.8 0.0 1.0,

--- a/src/app/game/services/timer-service.ts
+++ b/src/app/game/services/timer-service.ts
@@ -63,7 +63,7 @@ export class TimerService implements Resetable {
 								this.victoryManager.leader.trackedData.cities.cities.length
 							}|r cities and needs ${HexColors.RED}${
 								VictoryManager.CITIES_TO_WIN - this.victoryManager.leader.trackedData.cities.cities.length
-							}|r more to win!${VictoryManager.PASSED_THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT ? ' (Overtime, win condition lowered)' : ''}`,
+							}|r more to win! ${VictoryManager.OVERTIME_ACTIVE ? ' (Overtime, win condition lowered)' : ''}`,
 							'Sound\\Interface\\ItemReceived.flac',
 							4
 						);

--- a/src/app/game/services/timer-service.ts
+++ b/src/app/game/services/timer-service.ts
@@ -63,7 +63,7 @@ export class TimerService implements Resetable {
 								this.victoryManager.leader.trackedData.cities.cities.length
 							}|r cities and needs ${HexColors.RED}${
 								VictoryManager.CITIES_TO_WIN - this.victoryManager.leader.trackedData.cities.cities.length
-							}|r more to win! ${VictoryManager.OVERTIME_ACTIVE ? ' (Overtime, win condition lowered)' : ''}`,
+							}|r more to win! ${VictoryManager.OVERTIME_ACTIVE ? ' (Overtime! Win condition dropped by 1)' : ''}`,
 							'Sound\\Interface\\ItemReceived.flac',
 							4
 						);

--- a/src/app/game/services/timer-service.ts
+++ b/src/app/game/services/timer-service.ts
@@ -47,6 +47,8 @@ export class TimerService implements Resetable {
 				if (this._tick == this._duration) {
 					if (this.victoryManager.checkCityVictory()) return false;
 
+					ScoreboardManager.updateScoreboardTitle();
+
 					PlayerManager.getInstance().players.forEach((player) => {
 						if (!player.status.isDead()) {
 							player.giveGold();
@@ -63,7 +65,7 @@ export class TimerService implements Resetable {
 								this.victoryManager.leader.trackedData.cities.cities.length
 							}|r cities and needs ${HexColors.RED}${
 								VictoryManager.CITIES_TO_WIN - this.victoryManager.leader.trackedData.cities.cities.length
-							}|r more to win! ${VictoryManager.OVERTIME_ACTIVE ? ' (Overtime! Win condition dropped by 1)' : ''}`,
+							}|r more to win! ${VictoryManager.OVERTIME_ACTIVE ? ` ${HexColors.RED}(Overtime is active!)|r` : ''}`,
 							'Sound\\Interface\\ItemReceived.flac',
 							4
 						);

--- a/src/app/game/services/timer-service.ts
+++ b/src/app/game/services/timer-service.ts
@@ -10,6 +10,7 @@ import { GlobalMessage } from 'src/app/utils/messages';
 import { PlayGlobalSound } from 'src/app/utils/utils';
 import { File } from 'w3ts';
 import { ScoreboardManager } from 'src/app/scoreboard/scoreboard-manager';
+import { TURN_DURATION_SECONDS } from 'src/configs/game-settings';
 
 /**
  * TimerService is a class responsible for managing the main game timer.
@@ -29,7 +30,7 @@ export class TimerService implements Resetable {
 	 */
 	public constructor(gameState: GameState) {
 		this._timer = CreateTimer();
-		this._duration = 60;
+		this._duration = TURN_DURATION_SECONDS;
 		this._tick = this._duration;
 		this._turn = 1;
 		this.gameState = gameState;
@@ -62,7 +63,7 @@ export class TimerService implements Resetable {
 								this.victoryManager.leader.trackedData.cities.cities.length
 							}|r cities and needs ${HexColors.RED}${
 								VictoryManager.CITIES_TO_WIN - this.victoryManager.leader.trackedData.cities.cities.length
-							}|r more to win!`,
+							}|r more to win!${VictoryManager.PASSED_THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT ? ' (Overtime, win condition lowered)' : ''}`,
 							'Sound\\Interface\\ItemReceived.flac',
 							4
 						);
@@ -123,5 +124,9 @@ export class TimerService implements Resetable {
 
 		BlzFrameSetText(BlzGetFrameByName('ResourceBarUpkeepText', 0), tick);
 		BlzFrameSetText(BlzGetFrameByName('ResourceBarSupplyText', 0), `${this._turn}`);
+	}
+
+	public getTurns(): number {
+		return this._turn;
 	}
 }

--- a/src/app/game/state/mode-selection.ts
+++ b/src/app/game/state/mode-selection.ts
@@ -24,6 +24,7 @@ export class ModeSelection implements GameState {
 			settingsContext.getSettings().Promode = 1;
 			settingsContext.getSettings().Fog = 1;
 			settingsContext.getSettings().Diplomacy.option = 1;
+			settingsContext.getSettings().Overtime.option = 1;
 			this.ui.hide();
 			this.end();
 		} else {
@@ -52,6 +53,7 @@ export class ModeSelection implements GameState {
 		settings.initStrategies();
 		settings.applyStrategy('Diplomacy');
 		settings.applyStrategy('Promode');
+		settings.applyStrategy('Overtime');
 		this.manager.updateState(this.nextState);
 	}
 }

--- a/src/app/managers/victory-manager.ts
+++ b/src/app/managers/victory-manager.ts
@@ -7,9 +7,11 @@ import { WinTracker } from '../game/services/win-tracker';
 export class VictoryManager {
 	private static instance: VictoryManager;
 	public static CITIES_TO_WIN: number;
-	public static OVERTIME_ACTIVE: boolean;
+	public static OVERTIME_ACTIVE: boolean = false;
 	public static OVERTIME_MODE: boolean;
-	public static THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN: number;
+	public static OVERTIME_ACTIVE_AT_TURN: number;
+	public static OVERTIME_TOTAL_TURNS: number = 0;
+	public static OVERTIME_TURNS_UNTIL_ACTIVE: number = 0;
 
 	private _leader: ActivePlayer;
 	private players: ActivePlayer[];
@@ -24,7 +26,7 @@ export class VictoryManager {
 		VictoryManager.CITIES_TO_WIN = Math.ceil(RegionToCity.size * CITIES_TO_WIN_MULTIPLIER);
 
 		VictoryManager.OVERTIME_ACTIVE = false;
-		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 0;
+		VictoryManager.OVERTIME_ACTIVE_AT_TURN = 0;
 	}
 
 	public static getInstance(): VictoryManager {
@@ -82,10 +84,14 @@ export class VictoryManager {
 	}
 
 	private calculateCitiesToWin(): number {
-		if (VictoryManager.OVERTIME_MODE && this.gameTimer.getTurns() >= VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN) {
+		if (VictoryManager.OVERTIME_MODE) {
+			VictoryManager.OVERTIME_TURNS_UNTIL_ACTIVE = VictoryManager.OVERTIME_ACTIVE_AT_TURN - this.gameTimer.getTurns();
+			VictoryManager.OVERTIME_TOTAL_TURNS = this.gameTimer.getTurns() - VictoryManager.OVERTIME_ACTIVE_AT_TURN;
+		}
+
+		if (VictoryManager.OVERTIME_MODE && this.gameTimer.getTurns() >= VictoryManager.OVERTIME_ACTIVE_AT_TURN) {
 			VictoryManager.OVERTIME_ACTIVE = true;
-			let turnsSinceThreshold = this.gameTimer.getTurns() - VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN;
-			return Math.ceil(RegionToCity.size * CITIES_TO_WIN_MULTIPLIER) - OVERTIME_MODIFIER * turnsSinceThreshold;
+			return Math.ceil(RegionToCity.size * CITIES_TO_WIN_MULTIPLIER) - OVERTIME_MODIFIER * VictoryManager.OVERTIME_TOTAL_TURNS;
 		}
 
 		return Math.ceil(RegionToCity.size * CITIES_TO_WIN_MULTIPLIER);

--- a/src/app/managers/victory-manager.ts
+++ b/src/app/managers/victory-manager.ts
@@ -85,7 +85,7 @@ export class VictoryManager {
 		if (VictoryManager.OVERTIME_MODE && this.gameTimer.getTurns() >= VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN) {
 			VictoryManager.OVERTIME_ACTIVE = true;
 			let turnsSinceThreshold = this.gameTimer.getTurns() - VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN;
-			return Math.ceil(RegionToCity.size * (CITIES_TO_WIN_MULTIPLIER - turnsSinceThreshold * OVERTIME_MODIFIER));
+			return Math.ceil(RegionToCity.size * CITIES_TO_WIN_MULTIPLIER) - OVERTIME_MODIFIER * turnsSinceThreshold;
 		}
 
 		return Math.ceil(RegionToCity.size * CITIES_TO_WIN_MULTIPLIER);

--- a/src/app/quests/quests.ts
+++ b/src/app/quests/quests.ts
@@ -6,6 +6,7 @@ export class Quests {
 		Quests.Credits();
 		Quests.Tutorial();
 		Quests.ArmyComposition();
+		Quests.OvertimeDescription();
 	}
 
 	private static Credits() {
@@ -21,12 +22,12 @@ export class Quests {
 
 	private static Tutorial() {
 		let description: string = 'The goal of the game is to conquer 135 cities and hold them until the end of the turn.';
-		description += ' To gain income you need to control a whole country when the turn ends.';
-		description += ' It is best to start with smaller countries to gain income quickly.';
-		description += ' Try to expand in a way that will keep your countries connected.';
-		description += ' Make sure to use your spawns, they are free units you get each turn form countries you own.';
-		description += ' Chat is essential in Risk, make sure to use it and read it. Diplomacy is key.';
-		description += ' Make sure to peace other players, but also be ready to be backstabbed when your are vulnerable.';
+		description += 'To gain income you need to control a whole country when the turn ends.';
+		description += 'It is best to start with smaller countries to gain income quickly.';
+		description += 'Try to expand in a way that will keep your countries connected.';
+		description += 'Make sure to use your spawns, they are free units you get each turn form countries you own.';
+		description += 'Chat is essential in Risk, make sure to use it and read it. Diplomacy is key.';
+		description += 'Make sure to peace other players, but also be ready to be backstabbed when your are vulnerable.';
 
 		Quests.BuildQuest('How to play', description, 'ReplaceableTextures\\WorldEditUI\\Editor-Random-Unit.blp', true);
 	}
@@ -46,6 +47,18 @@ export class Quests {
 		description += ' It should only really be used the first couple of turns in fights on specific coastlines.';
 
 		Quests.BuildQuest('Army Composition', description, 'ReplaceableTextures\\WorldEditUI\\Editor-MultipleUnits.blp', true);
+	}
+
+	private static OvertimeDescription() {
+		let description: string =
+			'Overtime is a feature designed to help conclude games more efficiently by gradually reducing the number of cities required for victory. Once activated, each turn decreases the victory threshold by one city until a player wins.';
+		description += '\nThere are three Overtime settings:';
+		description += '\n1. Turbo Mode: Overtime begins at turn 30, accelerating the game pace early on.';
+		description += '\n2. Long Form Mode: Overtime starts at turn 120, allowing for extended gameplay before the mechanic activates.';
+		description += '\n3. Off: Overtime is disabled, keeping the default victory conditions.';
+		description += '\nThis system ensures flexibility and adaptability based on player preferences.';
+
+		Quests.BuildQuest('Overtime Explained', description, 'ReplaceableTextures\\CommandButtons\\BTNSorceressMaster.blp', true);
 	}
 
 	private static BuildQuest(title: string, description: string, icon: string, required: boolean) {

--- a/src/app/scoreboard/scoreboard-manager.ts
+++ b/src/app/scoreboard/scoreboard-manager.ts
@@ -87,7 +87,7 @@ export class ScoreboardManager {
 			ScoreboardManager.getInstance().setTitle(
 				`${NameManager.getInstance().getDisplayName(VictoryManager.getInstance().leader.getPlayer())} ${
 					VictoryManager.getInstance().leader.trackedData.cities.cities.length
-				}/${VictoryManager.CITIES_TO_WIN}${VictoryManager.OVERTIME_MODE ? ` (Turns until overtime: (${VictoryManager.OVERTIME_TURNS_UNTIL_ACTIVE})` : ''}`
+				}/${VictoryManager.CITIES_TO_WIN}${VictoryManager.OVERTIME_MODE ? ` (Turns until overtime: ${VictoryManager.OVERTIME_TURNS_UNTIL_ACTIVE})` : ''}`
 			);
 		}
 	}

--- a/src/app/scoreboard/scoreboard-manager.ts
+++ b/src/app/scoreboard/scoreboard-manager.ts
@@ -1,4 +1,7 @@
+import { NameManager } from '../managers/names/name-manager';
+import { VictoryManager } from '../managers/victory-manager';
 import { ActivePlayer } from '../player/types/active-player';
+import { HexColors } from '../utils/hex-colors';
 import { ObserverBoard } from './observer-board';
 import { Scoreboard } from './scoreboard';
 import { StandardBoard } from './standard-board';
@@ -71,5 +74,21 @@ export class ScoreboardManager {
 				callback(board);
 			}
 		});
+	}
+
+	public static updateScoreboardTitle() {
+		if (VictoryManager.OVERTIME_ACTIVE) {
+			ScoreboardManager.getInstance().setTitle(
+				`${NameManager.getInstance().getDisplayName(VictoryManager.getInstance().leader.getPlayer())} ${
+					VictoryManager.getInstance().leader.trackedData.cities.cities.length
+				}/${HexColors.RED}${VictoryManager.CITIES_TO_WIN}|r ${HexColors.RED}(Overtime)|r`
+			);
+		} else {
+			ScoreboardManager.getInstance().setTitle(
+				`${NameManager.getInstance().getDisplayName(VictoryManager.getInstance().leader.getPlayer())} ${
+					VictoryManager.getInstance().leader.trackedData.cities.cities.length
+				}/${VictoryManager.CITIES_TO_WIN}${VictoryManager.OVERTIME_MODE ? ` (Turns until overtime: (${VictoryManager.OVERTIME_TURNS_UNTIL_ACTIVE})` : ''}`
+			);
+		}
 	}
 }

--- a/src/app/settings/settings-context.ts
+++ b/src/app/settings/settings-context.ts
@@ -4,8 +4,9 @@ import { FogStrategy } from './strategies/fog-strategy';
 import { GameTypeStrategy } from './strategies/game-type-strategy';
 import { PromodeStrategy } from './strategies/promode-strategy';
 import { Settings } from './settings';
+import { OvertimeStrategy } from './strategies/overtime-strategy';
 
-export type SettingsKey = 'GameType' | 'Diplomacy' | 'Fog' | 'Promode';
+export type SettingsKey = 'GameType' | 'Diplomacy' | 'Fog' | 'Promode' | 'Overtime';
 
 export class SettingsContext {
 	private static instance: SettingsContext;
@@ -27,6 +28,9 @@ export class SettingsContext {
 				},
 				Fog: 0,
 				Promode: 0,
+				Overtime: {
+					option: 0,
+				},
 			});
 		}
 
@@ -38,6 +42,7 @@ export class SettingsContext {
 		this.strategies.set('Diplomacy', new DiplomacyStrategy(this.settings.Diplomacy));
 		this.strategies.set('Fog', new FogStrategy(this.settings.Fog));
 		this.strategies.set('Promode', new PromodeStrategy(this.settings.Promode));
+		this.strategies.set('Overtime', new OvertimeStrategy(this.settings.Overtime));
 	}
 
 	/**

--- a/src/app/settings/settings-view.ts
+++ b/src/app/settings/settings-view.ts
@@ -174,13 +174,13 @@ export class SettingsView {
 					SettingsContext.getInstance().getSettings().Promode = 1;
 					SettingsContext.getInstance().getSettings().Fog = 1;
 					SettingsContext.getInstance().getSettings().Diplomacy.option = 1;
-					SettingsContext.getInstance().getSettings().Overtime.option = 1;
+					SettingsContext.getInstance().getSettings().Overtime.option = 3;
 
 					BlzFrameSetValue(fogFrame, 1);
 					BlzFrameSetEnable(fogFrame, false);
 					BlzFrameSetValue(diploFrame, 1);
 					BlzFrameSetEnable(diploFrame, false);
-					BlzFrameSetValue(overtimeFrame, 1);
+					BlzFrameSetValue(overtimeFrame, 3);
 					BlzFrameSetEnable(overtimeFrame, false);
 				} else {
 					SettingsContext.getInstance().getSettings().Promode = 0;

--- a/src/app/settings/settings-view.ts
+++ b/src/app/settings/settings-view.ts
@@ -3,6 +3,7 @@ import { SettingsContext } from './settings-context';
 import { DiplomacyStrings } from './strategies/diplomacy-strategy';
 import { FogOptions } from './strategies/fog-strategy';
 import { GameTypeOptions } from './strategies/game-type-strategy';
+import { OvertimeStrings } from './strategies/overtime-strategy';
 import { PromodeOptions } from './strategies/promode-strategy';
 
 export class SettingsView {
@@ -14,11 +15,13 @@ export class SettingsView {
 		BlzFrameSetValue(BlzGetFrameByName('GameTypePopup', 0), 0);
 		BlzFrameSetValue(BlzGetFrameByName('FogPopup', 0), 0);
 		BlzFrameSetValue(BlzGetFrameByName('DiplomacyPopup', 0), 0);
+		BlzFrameSetValue(BlzGetFrameByName('OvertimePopup', 0), 0);
 		this.buildStartButton();
 		this.buildTimer();
 		this.gameTypePopup();
 		this.fogPopup();
 		this.diplomacyPopup();
+		this.overtimePopup();
 		this.promodeBox();
 		this.hostSetup();
 		this.playerSetup();
@@ -132,6 +135,28 @@ export class SettingsView {
 		BlzFrameSetText(BlzFrameGetChild(BlzGetFrameByName('DiplomacyPopup', 0), 2), `${DiplomacyStrings[value]}`);
 	}
 
+	private overtimePopup() {
+		const t: trigger = CreateTrigger();
+
+		BlzTriggerRegisterFrameEvent(t, BlzGetFrameByName('OvertimePopup', 0), FRAMEEVENT_POPUPMENU_ITEM_CHANGED);
+		TriggerAddCondition(
+			t,
+			Condition(() => {
+				const frameValue: number = R2I(BlzGetTriggerFrameValue());
+
+				SettingsContext.getInstance().getSettings().Overtime.option = frameValue;
+				this.colorizeOvertimeText(frameValue);
+			})
+		);
+
+		this.colorizeOvertimeText(BlzFrameGetValue(BlzGetFrameByName('OvertimePopup', 0)));
+	}
+
+	private colorizeOvertimeText(value: number) {
+		BlzFrameSetText(BlzGetFrameByName('OvertimeOption', 0), `${OvertimeStrings[value]}`);
+		BlzFrameSetText(BlzFrameGetChild(BlzGetFrameByName('OvertimePopup', 0), 3), `${OvertimeStrings[value]}`);
+	}
+
 	private promodeBox() {
 		const frame: framehandle = BlzGetFrameByName('PromodeCheckbox', 0);
 		const t: trigger = CreateTrigger();
@@ -143,28 +168,36 @@ export class SettingsView {
 			Condition(() => {
 				const fogFrame: framehandle = BlzGetFrameByName('FogPopup', 0);
 				const diploFrame: framehandle = BlzGetFrameByName('DiplomacyPopup', 0);
+				const overtimeFrame: framehandle = BlzGetFrameByName('OvertimePopup', 0);
 
 				if (BlzGetTriggerFrameEvent() == FRAMEEVENT_CHECKBOX_CHECKED) {
 					SettingsContext.getInstance().getSettings().Promode = 1;
 					SettingsContext.getInstance().getSettings().Fog = 1;
 					SettingsContext.getInstance().getSettings().Diplomacy.option = 1;
+					SettingsContext.getInstance().getSettings().Overtime.option = 1;
 
 					BlzFrameSetValue(fogFrame, 1);
 					BlzFrameSetEnable(fogFrame, false);
 					BlzFrameSetValue(diploFrame, 1);
 					BlzFrameSetEnable(diploFrame, false);
+					BlzFrameSetValue(overtimeFrame, 1);
+					BlzFrameSetEnable(overtimeFrame, false);
 				} else {
 					SettingsContext.getInstance().getSettings().Promode = 0;
 					SettingsContext.getInstance().getSettings().Fog = 0;
 					SettingsContext.getInstance().getSettings().Diplomacy.option = 0;
+					SettingsContext.getInstance().getSettings().Overtime.option = 0;
 					BlzFrameSetValue(fogFrame, 0);
 					BlzFrameSetEnable(fogFrame, true);
 					BlzFrameSetValue(diploFrame, 0);
 					BlzFrameSetEnable(diploFrame, true);
+					BlzFrameSetValue(overtimeFrame, 0);
+					BlzFrameSetEnable(overtimeFrame, true);
 				}
 
 				this.colorizeFogText(BlzFrameGetValue(fogFrame));
 				this.colorizeDiplomacyText(BlzFrameGetValue(diploFrame));
+				this.colorizeOvertimeText(BlzFrameGetValue(overtimeFrame));
 				BlzFrameSetText(BlzGetFrameByName('PromodeOption', 0), `${PromodeOptions[SettingsContext.getInstance().getSettings().Promode]}`);
 			})
 		);

--- a/src/app/settings/settings-view.ts
+++ b/src/app/settings/settings-view.ts
@@ -174,13 +174,13 @@ export class SettingsView {
 					SettingsContext.getInstance().getSettings().Promode = 1;
 					SettingsContext.getInstance().getSettings().Fog = 1;
 					SettingsContext.getInstance().getSettings().Diplomacy.option = 1;
-					SettingsContext.getInstance().getSettings().Overtime.option = 0;
+					SettingsContext.getInstance().getSettings().Overtime.option = 2;
 
 					BlzFrameSetValue(fogFrame, 1);
 					BlzFrameSetEnable(fogFrame, false);
 					BlzFrameSetValue(diploFrame, 1);
 					BlzFrameSetEnable(diploFrame, false);
-					BlzFrameSetValue(overtimeFrame, 0);
+					BlzFrameSetValue(overtimeFrame, 2);
 					BlzFrameSetEnable(overtimeFrame, false);
 				} else {
 					SettingsContext.getInstance().getSettings().Promode = 0;

--- a/src/app/settings/settings-view.ts
+++ b/src/app/settings/settings-view.ts
@@ -174,13 +174,13 @@ export class SettingsView {
 					SettingsContext.getInstance().getSettings().Promode = 1;
 					SettingsContext.getInstance().getSettings().Fog = 1;
 					SettingsContext.getInstance().getSettings().Diplomacy.option = 1;
-					SettingsContext.getInstance().getSettings().Overtime.option = 3;
+					SettingsContext.getInstance().getSettings().Overtime.option = 0;
 
 					BlzFrameSetValue(fogFrame, 1);
 					BlzFrameSetEnable(fogFrame, false);
 					BlzFrameSetValue(diploFrame, 1);
 					BlzFrameSetEnable(diploFrame, false);
-					BlzFrameSetValue(overtimeFrame, 3);
+					BlzFrameSetValue(overtimeFrame, 0);
 					BlzFrameSetEnable(overtimeFrame, false);
 				} else {
 					SettingsContext.getInstance().getSettings().Promode = 0;

--- a/src/app/settings/settings.ts
+++ b/src/app/settings/settings.ts
@@ -1,8 +1,10 @@
 import { DiplomacyOptions } from './strategies/diplomacy-strategy';
+import { OvertimeOptions } from './strategies/overtime-strategy';
 
 export interface Settings {
 	GameType: number;
 	Diplomacy: DiplomacyOptions;
 	Fog: number;
 	Promode: number;
+	Overtime: OvertimeOptions;
 }

--- a/src/app/settings/strategies/overtime-strategy.ts
+++ b/src/app/settings/strategies/overtime-strategy.ts
@@ -1,0 +1,55 @@
+import { VictoryManager } from 'src/app/managers/victory-manager';
+import { SettingsStrategy } from './settings-strategy';
+import { HexColors } from 'src/app/utils/hex-colors';
+
+export interface OvertimeOptions {
+	option: number;
+}
+
+export const OvertimeStrings: Record<number, string> = {
+	0: `${HexColors.GREEN}Off`,
+	1: `${HexColors.RED}Turn 30`,
+	2: `${HexColors.RED}Turn 60`,
+	3: `${HexColors.RED}Turn 90`,
+};
+
+export class OvertimeStrategy implements SettingsStrategy {
+	private readonly overtime: OvertimeOptions;
+	private readonly strategyMap: Map<number, () => void> = new Map([
+		[0, this.handleOff],
+		[1, this.handleTurn30],
+		[2, this.handleTurn60],
+		[3, this.handleTurn90],
+	]);
+
+	constructor(overtime: OvertimeOptions) {
+		this.overtime = overtime;
+	}
+
+	public apply(): void {
+		const handler = this.strategyMap.get(this.overtime.option);
+		if (handler) {
+			handler();
+		}
+	}
+
+	private handleOff(): void {
+		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 0;
+		VictoryManager.OVERTIME_MODE = false;
+	}
+
+	private handleTurn30(): void {
+		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 30;
+		VictoryManager.OVERTIME_MODE = true;
+	}
+
+	private handleTurn60(): void {
+		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 60;
+		VictoryManager.OVERTIME_MODE = true;
+	}
+
+	private handleTurn90(): void {
+		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 90;
+		VictoryManager.OVERTIME_MODE = true;
+	}
+}

--- a/src/app/settings/strategies/overtime-strategy.ts
+++ b/src/app/settings/strategies/overtime-strategy.ts
@@ -7,19 +7,17 @@ export interface OvertimeOptions {
 }
 
 export const OvertimeStrings: Record<number, string> = {
-	0: `${HexColors.GREEN}Off`,
-	1: `${HexColors.RED}Turn 60`,
-	2: `${HexColors.RED}Turn 90`,
-	3: `${HexColors.RED}Turn 120`,
+	0: `${HexColors.GREEN}Turbo (Turn 30)`,
+	1: `${HexColors.RED}Long (Turn 120)`,
+	2: `${HexColors.RED}Off`,
 };
 
 export class OvertimeStrategy implements SettingsStrategy {
 	private readonly overtime: OvertimeOptions;
 	private readonly strategyMap: Map<number, () => void> = new Map([
-		[0, this.handleOff],
-		[1, this.handleOption1],
-		[2, this.handleOption2],
-		[3, this.handleOption3],
+		[0, this.handleTurboOption],
+		[1, this.handleLongOption],
+		[2, this.handleOff],
 	]);
 
 	constructor(overtime: OvertimeOptions) {
@@ -33,23 +31,18 @@ export class OvertimeStrategy implements SettingsStrategy {
 		}
 	}
 
+	private handleTurboOption(): void {
+		VictoryManager.OVERTIME_ACTIVE_AT_TURN = 30;
+		VictoryManager.OVERTIME_MODE = true;
+	}
+
+	private handleLongOption(): void {
+		VictoryManager.OVERTIME_ACTIVE_AT_TURN = 120;
+		VictoryManager.OVERTIME_MODE = true;
+	}
+
 	private handleOff(): void {
 		VictoryManager.OVERTIME_ACTIVE_AT_TURN = 0;
 		VictoryManager.OVERTIME_MODE = false;
-	}
-
-	private handleOption1(): void {
-		VictoryManager.OVERTIME_ACTIVE_AT_TURN = 60;
-		VictoryManager.OVERTIME_MODE = true;
-	}
-
-	private handleOption2(): void {
-		VictoryManager.OVERTIME_ACTIVE_AT_TURN = 90;
-		VictoryManager.OVERTIME_MODE = true;
-	}
-
-	private handleOption3(): void {
-		VictoryManager.OVERTIME_ACTIVE_AT_TURN = 120;
-		VictoryManager.OVERTIME_MODE = true;
 	}
 }

--- a/src/app/settings/strategies/overtime-strategy.ts
+++ b/src/app/settings/strategies/overtime-strategy.ts
@@ -34,22 +34,22 @@ export class OvertimeStrategy implements SettingsStrategy {
 	}
 
 	private handleOff(): void {
-		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 0;
+		VictoryManager.OVERTIME_ACTIVE_AT_TURN = 0;
 		VictoryManager.OVERTIME_MODE = false;
 	}
 
 	private handleOption1(): void {
-		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 60;
+		VictoryManager.OVERTIME_ACTIVE_AT_TURN = 60;
 		VictoryManager.OVERTIME_MODE = true;
 	}
 
 	private handleOption2(): void {
-		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 90;
+		VictoryManager.OVERTIME_ACTIVE_AT_TURN = 90;
 		VictoryManager.OVERTIME_MODE = true;
 	}
 
 	private handleOption3(): void {
-		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 120;
+		VictoryManager.OVERTIME_ACTIVE_AT_TURN = 120;
 		VictoryManager.OVERTIME_MODE = true;
 	}
 }

--- a/src/app/settings/strategies/overtime-strategy.ts
+++ b/src/app/settings/strategies/overtime-strategy.ts
@@ -8,18 +8,18 @@ export interface OvertimeOptions {
 
 export const OvertimeStrings: Record<number, string> = {
 	0: `${HexColors.GREEN}Off`,
-	1: `${HexColors.RED}Turn 30`,
-	2: `${HexColors.RED}Turn 60`,
-	3: `${HexColors.RED}Turn 90`,
+	1: `${HexColors.RED}Turn 60`,
+	2: `${HexColors.RED}Turn 90`,
+	3: `${HexColors.RED}Turn 120`,
 };
 
 export class OvertimeStrategy implements SettingsStrategy {
 	private readonly overtime: OvertimeOptions;
 	private readonly strategyMap: Map<number, () => void> = new Map([
 		[0, this.handleOff],
-		[1, this.handleTurn30],
-		[2, this.handleTurn60],
-		[3, this.handleTurn90],
+		[1, this.handleOption1],
+		[2, this.handleOption2],
+		[3, this.handleOption3],
 	]);
 
 	constructor(overtime: OvertimeOptions) {
@@ -38,18 +38,18 @@ export class OvertimeStrategy implements SettingsStrategy {
 		VictoryManager.OVERTIME_MODE = false;
 	}
 
-	private handleTurn30(): void {
-		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 30;
-		VictoryManager.OVERTIME_MODE = true;
-	}
-
-	private handleTurn60(): void {
+	private handleOption1(): void {
 		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 60;
 		VictoryManager.OVERTIME_MODE = true;
 	}
 
-	private handleTurn90(): void {
+	private handleOption2(): void {
 		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 90;
+		VictoryManager.OVERTIME_MODE = true;
+	}
+
+	private handleOption3(): void {
+		VictoryManager.THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN = 120;
 		VictoryManager.OVERTIME_MODE = true;
 	}
 }

--- a/src/app/triggers/ownership-change-event.ts
+++ b/src/app/triggers/ownership-change-event.ts
@@ -2,7 +2,6 @@ import { City } from '../city/city';
 import { UnitToCity } from '../city/city-map';
 import { Country } from '../country/country';
 import { CityToCountry } from '../country/country-map';
-import { NameManager } from '../managers/names/name-manager';
 import { VictoryManager } from '../managers/victory-manager';
 import { PlayerManager } from '../player/player-manager';
 import { PLAYER_STATUS } from '../player/status/status-enum';
@@ -125,11 +124,7 @@ export function OwnershipChangeEvent() {
 					teamManager.getTeamFromPlayer(ownerHandle).updateCityCount(1);
 				}
 
-				ScoreboardManager.getInstance().setTitle(
-					`${NameManager.getInstance().getDisplayName(VictoryManager.getInstance().leader.getPlayer())} ${
-						VictoryManager.getInstance().leader.trackedData.cities.cities.length
-					}/${VictoryManager.CITIES_TO_WIN} `
-				);
+				ScoreboardManager.updateScoreboardTitle();
 			}
 
 			return false;

--- a/src/app/utils/map-info.ts
+++ b/src/app/utils/map-info.ts
@@ -1,5 +1,5 @@
 
 	//Do not edit - this will automatically update based on the project config.json upon building the map
 	export const MAP_NAME: string = 'Risk Europe';
-	export const MAP_VERSION: string = '2.05a';
+	export const MAP_VERSION: string = '2.05b';
   

--- a/src/app/utils/map-info.ts
+++ b/src/app/utils/map-info.ts
@@ -1,5 +1,3 @@
-
-	//Do not edit - this will automatically update based on the project config.json upon building the map
-	export const MAP_NAME: string = 'Risk Europe';
-	export const MAP_VERSION: string = '2.05';
-  
+//Do not edit - this will automatically update based on the project config.json upon building the map
+export const MAP_NAME: string = 'Risk Europe';
+export const MAP_VERSION: string = '2.05a';

--- a/src/app/utils/map-info.ts
+++ b/src/app/utils/map-info.ts
@@ -1,5 +1,5 @@
 
 	//Do not edit - this will automatically update based on the project config.json upon building the map
 	export const MAP_NAME: string = 'Risk Europe';
-	export const MAP_VERSION: string = '2.05b';
+	export const MAP_VERSION: string = '2.05c';
   

--- a/src/app/utils/map-info.ts
+++ b/src/app/utils/map-info.ts
@@ -1,3 +1,5 @@
-//Do not edit - this will automatically update based on the project config.json upon building the map
-export const MAP_NAME: string = 'Risk Europe';
-export const MAP_VERSION: string = '2.05a';
+
+	//Do not edit - this will automatically update based on the project config.json upon building the map
+	export const MAP_NAME: string = 'Risk Europe';
+	export const MAP_VERSION: string = '2.05a';
+  

--- a/src/app/utils/map-info.ts
+++ b/src/app/utils/map-info.ts
@@ -1,5 +1,5 @@
 
 	//Do not edit - this will automatically update based on the project config.json upon building the map
 	export const MAP_NAME: string = 'Risk Europe';
-	export const MAP_VERSION: string = '2.04c';
+	export const MAP_VERSION: string = '2.05';
   

--- a/src/configs/game-settings.ts
+++ b/src/configs/game-settings.ts
@@ -1,12 +1,12 @@
 //Used to control how many of total cities you need.
 //This is a percentage of the total cities .6 = 60%
-export const CITIES_TO_WIN_MULTIPLIER: number = 0.13;
+export const CITIES_TO_WIN_MULTIPLIER: number = 0.6;
 
 //This is the starting gold for each player. 4 by default.
 export const STARTING_INCOME: number = 4;
 
 //This is the duration of a turn in seconds. 60 by default.
-export const TURN_DURATION_SECONDS: number = 5;
+export const TURN_DURATION_SECONDS: number = 60;
 
 //This is the modifier for the reduced win requirement. 0.01 is approximately 2 cities.
 export const OVERTIME_MODIFIER: number = 0.01;

--- a/src/configs/game-settings.ts
+++ b/src/configs/game-settings.ts
@@ -8,5 +8,5 @@ export const STARTING_INCOME: number = 4;
 //This is the duration of a turn in seconds. 60 by default.
 export const TURN_DURATION_SECONDS: number = 60;
 
-//This is the modifier for the reduced win requirement. 0.01 is approximately 2 cities.
-export const OVERTIME_MODIFIER: number = 0.01;
+//This represents the drop in required cities to win each turn. Default is 1.
+export const OVERTIME_MODIFIER: number = 1;

--- a/src/configs/game-settings.ts
+++ b/src/configs/game-settings.ts
@@ -1,17 +1,12 @@
 //Used to control how many of total cities you need.
 //This is a percentage of the total cities .6 = 60%
-export const CITIES_TO_WIN_MULTIPLIER: number = 0.6;
+export const CITIES_TO_WIN_MULTIPLIER: number = 0.13;
 
 //This is the starting gold for each player. 4 by default.
 export const STARTING_INCOME: number = 4;
 
 //This is the duration of a turn in seconds. 60 by default.
-export const TURN_DURATION_SECONDS: number = 60;
-
-//This is the turn number for when the cities requirement
-//is reduced by 1 percent each turn.
-//90 by default, whhich is 1 hour and 30 minutes.
-export const THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN: number = 90;
+export const TURN_DURATION_SECONDS: number = 5;
 
 //This is the modifier for the reduced win requirement. 0.01 is approximately 2 cities.
-export const THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_MODIFIER: number = 0.01;
+export const OVERTIME_MODIFIER: number = 0.01;

--- a/src/configs/game-settings.ts
+++ b/src/configs/game-settings.ts
@@ -2,4 +2,16 @@
 //This is a percentage of the total cities .6 = 60%
 export const CITIES_TO_WIN_MULTIPLIER: number = 0.6;
 
+//This is the starting gold for each player. 4 by default.
 export const STARTING_INCOME: number = 4;
+
+//This is the duration of a turn in seconds. 60 by default.
+export const TURN_DURATION_SECONDS: number = 60;
+
+//This is the turn number for when the cities requirement
+//is reduced by 1 percent each turn.
+//90 by default, whhich is 1 hour and 30 minutes.
+export const THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN: number = 90;
+
+//This is the modifier for the reduced win requirement. 0.01 is approximately 2 cities.
+export const THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_MODIFIER: number = 0.01;

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,6 @@ import CameraManager from './app/managers/camera-manager';
 import { TimedEventManager } from './app/libs/timer/timed-event-manager';
 import { AntiSpam } from './app/triggers/anti-spam';
 import { SetCommands } from './app/commands/commands';
-import { File } from 'w3ts';
 
 //const BUILD_DATE = compiletime(() => new Date().toUTCString());
 


### PR DESCRIPTION
# Proposal
This PR is an attempt at discussing and addressing my concern related to too long games. Specifically, games that last too long due to stalemates. I recognize that this a major change from tradition, so I expect this PR to be thoroughly scrutinized.

The current proposed solution is mostly inspired by warden@discord by reducing the required cities owned to win the game by %. The original proposal adjusted the win condition every 5 rounds. I adjusted the proposal slightly as follows: Each round past round 90 reduces the required amount of cities by 1%, which roughly equates to 2 cities. 

Expected results
- The change will force players in stalemate situations to be proactive. 
- This will also, as a side effect, ensure that there is some predictability in terms of game lengths, at least on the max length side. 

In summary, it is a major departure from how Risk Reforge has worked, however, I am certain that this would long term benefit the game. Games would be quicker with more predictable lengths and stalemates are forcefully resolved. 

Discussions and suggestions on improving this PR would be great. 

Video demonstrates the concept:
https://drive.google.com/file/d/1mHk3Wr9JK-N6PDK5iBO9jRctdeLl19gO/view?usp=sharing

You can change the content of the game-settings.ts file with the following content to quickly test this functionality with lower test values.

## Test data
```
//Used to control how many of total cities you need.
//This is a percentage of the total cities .6 = 60%
export const CITIES_TO_WIN_MULTIPLIER: number = 0.13;

//This is the starting gold for each player. 4 by default.
export const STARTING_INCOME: number = 4;

//This is the duration of a turn in seconds. 60 by default.
export const TURN_DURATION_SECONDS: number = 5;

//This is the turn number for when the cities requirement
//is reduced by 1 percent each turn.
//90 by default, whhich is 1 hour and 30 minutes.
export const THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_TURN: number = 3;

//This is the modifier for the reduced win requirement. 0.01 is approximately 2 cities.
export const THRESHOLD_FOR_REDUCED_WIN_REQUIREMENT_MODIFIER: number = 0.01;
```