### PR TITLE
Project setup now uses .env for dev specific configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Wc3 Risk System is a portable custom game system for Warcraft 3. Risk is based off of the ideas and concepts from the<br> board game Risk: Global Domination.
 The system is designed to be easily used by others who are wanting to create their own version of Risk in Warcraft 3 with minimal coding invovled.
 
-
 ## Table of Contents
+
 - [Introduction](#introduction)
 - [Features](#features)
 - [Getting Started](#getting-started)
@@ -21,6 +21,7 @@ Welcome to the Wc3 Risk System, my passion project and a labor of love for the W
 The idea for the Wc3 Risk System was born out of my deep affection for both Warcraft 3 and the strategic gameplay of "Risk." Combining the best of both worlds, my goal is to deliver an accessible yet intricate gaming experience that appeals to both casual players and seasoned strategists.
 
 **Key Highlights**
+
 - Engage in epic battles with up to 23 players in a Free-for-All (FFA) or Team style gameplay.
 - Experience different game modes, including the intense 1v1 mode and inventive variations like "Capitals."
 - Enjoy a user-friendly system that facilitates easy customization, allowing aspiring developers and modders to create their own Risk-inspired games within Warcraft 3.
@@ -40,33 +41,54 @@ My risk system is designed for fellow Warcraft 3 enthusiasts who crave a unique 
 ## Getting Started
 
 **Requirements**
-1. [Node.js](https://nodejs.org/) *Node version 18 or greater, as of 8/1/2023 it has been tested with version 18.17.0 LTS.
+
+1. [Node.js](https://nodejs.org/) \*Node version 18 or greater, as of 8/1/2023 it has been tested with version 18.17.0 LTS.
 2. Warcraft III verison 1.31.0 or greater.
 
 **Project Setup**
+
 1. [Download](https://github.com/dtchitt/wc3-risk-system/archive/refs/heads/main.zip) (or clone) the repo and cd into the project root.
+
 ```bash
 cd wc3-risk-system
 ```
+
 2. Install the dependencies.
+
 ```
 npm install
 ```
-3. Configure your project by editing config.json and making sure gameExecutable properly points to your Warcraft III game executable.<br>
+
+3. Configure your project by creating a .env file with gameExecutable evnrionment variable that properly points to your Warcraft III game executable.<br>
+
+**Setting up .env**
+
+To simplify collaboration, an .env file is used to store local references to the game executable as well as a build folder that is accessible from within the game. If you haven't already, start by creating a .env file in the repository root directory. Adjust the following sample environment values to point to your local executable and build directory. These values are injected into the config.json files when running commands.
+
+Ensure that the .env file is not committed to the repository.
+
+```
+GAME_EXECUTABLE=C:\\Program Files (x86)\\Warcraft III\\_retail_\\x86_64\\Warcraft III.exe
+OUTPUT_FOLDER=C:\\Users\\{USERNAME}\\Documents\\Warcraft III\\Maps\\Download\\(0) testing
+```
+
+Running the build command will automatically generate the path and required directories.
+
 Check out the base [wc3-ts-template](https://cipherxof.github.io/w3ts/docs/getting-started) for more detials on installation and usage
 
 ## Usage
 
 **Testing the project locally**
+
 ```
 npm run test
 ```
 
 **Building the project for release**
+
 ```
 npm run build
 ```
-
 
 ## Documentation
 
@@ -79,4 +101,3 @@ TODO
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
 	"mapName": "Risk Europe",
 	"mapVersion": "2.04c",
 	"minifyScript": false,
-	"gameExecutable": "D:\\Warcraft III\\_retail_\\x86_64\\Warcraft III.exe",
-	"outputFolder": "C:\\Users\\Daniel\\Documents\\Warcraft III\\Maps\\Download\\(0) testing",
+	"gameExecutable": "${GAME_EXECUTABLE}",
+	"outputFolder": "${OUTPUT_FOLDER}",
 	"launchArgs": ["-launch", "-windowmode", "windowed"]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "build:defs": "ts-node scripts/dev"
   },
   "dependencies": {
-    "w3ts": "^3.0.2"
+    "dotenv": "^16.4.7",
+    "w3ts": "^3.0.2",
+    "wc3-ts-template": "file:"
   },
   "devDependencies": {
     "@types/fs-extra": "8.1.1",

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,31 +1,35 @@
-import {exec, execFile, execSync} from "child_process";
-import {loadJsonFile, logger, compileMap, IProjectConfig} from "./utils";
+import { exec, execFile, execSync } from 'child_process';
+import { loadJsonFile, logger, compileMap, IProjectConfig } from './utils';
 
 function main() {
-  const config: IProjectConfig = loadJsonFile("config.json");
-  const result = compileMap(config);
+	const config: IProjectConfig = loadJsonFile('config.json');
+	const result = compileMap(config);
 
-  if (!result) {
-    logger.error(`Failed to compile map.`);
-    return;
-  }
+	if (!result) {
+		logger.error(`Failed to compile map.`);
+		return;
+	}
 
-  const cwd = process.cwd();
-  const filename = `${cwd}/dist/${config.mapFolder}`;
+	const cwd = process.cwd();
+	const filename = `${cwd}/dist/${config.mapFolder}`;
 
-  logger.info(`Launching map "${filename.replace(/\\/g, "/")}"...`);
+	logger.info(`Launching map "${filename.replace(/\\/g, '/')}"...`);
 
-  if(config.winePath) {
-    const wineFilename = `"Z:${filename}"`
-    const prefix = config.winePrefix ? `WINEPREFIX=${config.winePrefix}` : ''
-    execSync(`${prefix} ${config.winePath} "${config.gameExecutable}" ${["-loadfile", wineFilename, ...config.launchArgs].join(' ')}`, { stdio: 'ignore' });
-  } else {
-    execFile(config.gameExecutable, ["-loadfile", filename, ...config.launchArgs], (err: any) => {
-      if (err && err.code === 'ENOENT') {
-        logger.error(`No such file or directory "${config.gameExecutable}". Make sure gameExecutable is configured properly in config.json.`);
-      }
-    });
-  }
+	if (config.winePath) {
+		const wineFilename = `"Z:${filename}"`;
+		const prefix = config.winePrefix ? `WINEPREFIX=${config.winePrefix}` : '';
+		execSync(`${prefix} ${config.winePath} "${config.gameExecutable}" ${['-loadfile', wineFilename, ...config.launchArgs].join(' ')}`, {
+			stdio: 'ignore',
+		});
+	} else {
+		execFile(config.gameExecutable, ['-loadfile', filename, ...config.launchArgs], (err: any) => {
+			if (err && err.code === 'ENOENT') {
+				logger.error(
+					`No such file or directory "${config.gameExecutable}". Make sure your GAME_EXECUTABLE environment variable is configured properly in your local .env.`
+				);
+			}
+		});
+	}
 }
 
 main();

--- a/src/app/game/state/post-game.ts
+++ b/src/app/game/state/post-game.ts
@@ -11,7 +11,6 @@ import { SettingsContext } from 'src/app/settings/settings-context';
 import { TreeManager } from '../services/tree-service';
 import { TeamManager } from 'src/app/teams/team-manager';
 import { Wait } from 'src/app/utils/wait';
-import { GameDataWriter } from 'src/app/utils/game-data-writer';
 
 export class PostGame implements GameState {
 	private manager: GameManager;

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,6 @@ import CameraManager from './app/managers/camera-manager';
 import { TimedEventManager } from './app/libs/timer/timed-event-manager';
 import { AntiSpam } from './app/triggers/anti-spam';
 import { SetCommands } from './app/commands/commands';
-import { File } from 'w3ts';
 
 //const BUILD_DATE = compiletime(() => new Date().toUTCString());
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,9 @@
     "plugins": [
       {
         "transform": "war3-transformer",
-        "mapDir": "C:/Users/Daniel/Desktop/wc3-risk-system/maps/risk_europe.w3x",
-        "entryFile": "C:/Users/Daniel/Desktop/wc3-risk-system/src/main.ts",
-        "outputDir": "C:/Users/Daniel/Desktop/wc3-risk-system/dist/risk_europe.w3x"
+        "mapDir": "../risk_europe.w3x",
+        "entryFile": "./src/main.ts",
+        "outputDir": "../risk_europe.w3x"
       }
     ],
     "types": [


### PR DESCRIPTION
Currently developers have to deal with their own machine specific configurations (game paths, map paths, etc.). It is an erroneous process in which their setup may be committed by accident.

This proposal is an attempt at resolving that issue, by encouraging developers to use a .env file at the repository root directory. The .env file contains gameExecutable and outputDirectory that must be configured. Once executing the test and build commands, the application will inject the environment variables into the config.json. 

.env is git ignored, and may contain environment specific configurations.

**Sample .env configurations**

```
GAME_EXECUTABLE=C:\\Program Files (x86)\\Warcraft III\\_retail_\\x86_64\\Warcraft III.exe
OUTPUT_FOLDER=C:\\Users\\{USERNAME}\\Documents\\Warcraft III\\Maps\\Download\\(0) testing
```

The readme.md file contains the full explaination.

Also, similarily, the tsconfig.json file will now only be injected relative paths and not full paths.